### PR TITLE
Fixes issue #4

### DIFF
--- a/haml/precompiler.lua
+++ b/haml/precompiler.lua
@@ -100,7 +100,7 @@ function methods:close_tags(func)
       if func and not func(self.endings:last()) then return end
         self:close_current()
       i = i + 1
-    until i == 0
+    until i >= 0
   end
 end
 


### PR DESCRIPTION
If the indentation on the current line has mixed spaces and tabs, this will prevent the precompiler from entering an infinite loop. It will still generate a tree that doesn't make sense; it would be better to somehow detect this case in __validate_whitespace, but I couldn't get that working right.
