### PR TITLE
Added a __newindex function on to the metatable for Haml environments. 

### DIFF
--- a/haml/renderer.lua
+++ b/haml/renderer.lua
@@ -16,6 +16,7 @@ local setmetatable = setmetatable
 local sorted_pairs = ext.sorted_pairs
 local tostring     = tostring
 local type         = type
+local rawset       = rawset
 
 module "haml.renderer"
 
@@ -120,7 +121,9 @@ function methods:render(locals)
 
   setmetatable(self.env, {__index = function(table, key)
     return locals[key] or _G[key]
-  end})
+  end,
+  __newindex = function(table, key, val) rawset(locals, key, val) end
+  })
 
   local succeeded, err = pcall(self.func)
   if not succeeded then


### PR DESCRIPTION
Before this change, you could put code into tag attributes like this:

```
%div{:class => "#{tbl.whatever}"}
```

But this only works if tbl is passed in as a local; that is, this won't work:

```
- tbl = {whatever='blah'}
%div{:class => "#{tbl.whatever}"}
```

This works by making the initial assignment to tbl put a new value in locals, instead of a new global value. This has the (IMO) nice side-effect of keeping bad Haml from polluting the global namespace.

Not sure if you actually want to pull this or not; unlike the last one (indentation stuff) this actually changes the semantics. I think it adds a useful feature though; at least it does for my markup. :)
